### PR TITLE
Make Hovering over Portfolio items use  Primary Color

### DIFF
--- a/_includes/css/agency.css
+++ b/_includes/css/agency.css
@@ -368,10 +368,10 @@ section h3.section-subheading {
     width: 100%;
     height: 100%;
     opacity: 0;
-    background: rgba(254,209,54,.9);
     -webkit-transition: all ease .5s;
     -moz-transition: all ease .5s;
     transition: all ease .5s;
+    background: rgba({{ site.color.primary | hex_to_rgb | join: ',' }}, .9);
 }
 
 #portfolio .portfolio-item .portfolio-link .portfolio-hover:hover {

--- a/_plugins/hex_to_rgb.rb
+++ b/_plugins/hex_to_rgb.rb
@@ -1,0 +1,32 @@
+# Simple hex conversion Liquid filter plugin
+#
+# Convert a string of hex values into an array of decimal values.
+#
+# Examples:
+#   {{ "aabbcc" | hex_to_rgb }}
+#   # => [170, 187, 204]
+#
+#   {{ "abc" | hex_to_rgb }}
+#   # => [170, 187, 204]
+#
+#   {{ "0a0b0c" | hex_to_rgb }}
+#   # => [10, 11, 12]
+#
+# hexval - string of valid hexidecimal characters
+#
+# Returns an array of decimal values for the parse hex characters
+#
+
+module Jekyll
+  module HexToRGB
+    def hex_to_rgb(hexval)
+      if hexval.length.even?
+        hexval.scan(/../).map {|color| color.to_i(16)}
+      else
+        hexval.scan(/./).map {|color| (color+color).to_i(16)}
+      end
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::HexToRGB)


### PR DESCRIPTION
I noticed that after switching the primary and secondary color in the config, hovering over portfolio items was still using the original primary color:

Example now:
![screen shot 2014-11-06 at 9 53 59 am](https://cloud.githubusercontent.com/assets/4104448/4937645/2a34cdcc-65c5-11e4-8d4e-96e34fdb198c.png)

I added a small plugin that adds a filter to simply change the hex values we have in the `_config.yml` as primary color into RGB values so we can keep the alpha of 0.9 that the hover currently uses

Example after this change:
![screen shot 2014-11-06 at 9 56 05 am](https://cloud.githubusercontent.com/assets/4104448/4937687/8a24cff2-65c5-11e4-9dad-5ddfaedb3007.png)
