### PR TITLE
Add fallback css for GitHub pages

### DIFF
--- a/_includes/css/agency.css
+++ b/_includes/css/agency.css
@@ -371,6 +371,7 @@ section h3.section-subheading {
     -webkit-transition: all ease .5s;
     -moz-transition: all ease .5s;
     transition: all ease .5s;
+    background: rgba(254,209,54,.9); /* Fallback when no plugin support */
     background: rgba({{ site.color.primary | hex_to_rgb | join: ',' }}, .9);
 }
 


### PR DESCRIPTION
Turns out things like GitHub pages generate sites with the `--safe` flag causing plugins to not be supported.

This add's a fallback background so it won't mess up everyone using this theme with GitHub pages.

Sorry about that!
