### PR TITLE
Include custom css content in styles layout

### DIFF
--- a/_layouts/style.css
+++ b/_layouts/style.css
@@ -1,2 +1,3 @@
 {% include css/bootstrap.min.css %}
 {% include css/agency.css %}
+{{ content }}


### PR DESCRIPTION
Currently if you add custom css to the style.css file, that new css will not actually appear anywhere on the website. This change ensures that the custom css is included on the website.
