### PR TITLE
Highlight directories in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,21 @@ Agency theme based on [Agency bootstrap theme ](http://startbootstrap.com/templa
 
 # How to use
 
-###Portfolio 
+###Portfolio
 
-Portfolio projects are in '/_posts'
+Portfolio projects are in `/_posts`
 
-Images are in '/img/portfolio'
+Images are in `/img/portfolio`
 
 ###About
 
-Images are in '/img/about/'
+Images are in `/img/about/`
 
 ###Team
 
-Team members and info are in '_config.yml'
+Team members and info are in `_config.yml`
 
-Images are in '/img/team/'
+Images are in `/img/team/`
 
 
 # Demo


### PR DESCRIPTION
Changed '/dir/' to `/dir/` in order to properly highlight all directories in README.md.