### PR TITLE
Fix for varying length portfolio subtitles

### DIFF
--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -23,6 +23,14 @@
                         <p class="text-muted">{{ post.subtitle }}</p>
                     </div>
                 </div>
+                {% assign twos = forloop.index | modulo: 2 %}
+                {% assign threes = forloop.index | modulo: 3 %}
+                {% if twos == 0 %}
+                    <div class="clearfix hidden-md hidden-lg"></div>
+                {% endif %}
+                {% if threes == 0 %}
+                    <div class="clearfix hidden-sm hidden-xs"></div>
+                {% endif %}
             {% endfor %}
             </div>
         </div>


### PR DESCRIPTION
I have been using your excellent theme, but wanted to add more text to the subtitles in posts to describe my portfolio projects. This fix allows for multiple length post subtitles whilst preserving the layout of the posts in the portfolio grid on different window sizes.